### PR TITLE
isolate async test to only test async property

### DIFF
--- a/2.13/tests/test/test.js
+++ b/2.13/tests/test/test.js
@@ -394,8 +394,12 @@ describe('DELETE /v2/service_instance/:instance_id', function() {
                 testAPIVersionHeader('/v2/service_instances/' + instance_id, 'DELETE');
                 testAuthentication('/v2/service_instances/' + instance_id, 'DELETE');
 
-                if (binding.async) 
-                    testAsyncParameter('/v2/service_instances/' + instance_id, 'DELETE');
+                if (binding.async)
+                    testAsyncParameter(
+                        '/v2/service_instances/' + instance_id
+                        + "?plan_id=" + binding.body.plan_id
+                        + "&service_id=" + binding.body.service_id,
+                        'DELETE');
 
                 describe("DELETE", function () { 
                     it ('should reject if missing service_id', function(done) {                


### PR DESCRIPTION
make sure `plan_id` and `service_id` are passed to ensure that the request does not fail early due to anything but the async property.