### PR TITLE
Update to check `last_operation` for async only

### DIFF
--- a/2.13/tests/test/test.js
+++ b/2.13/tests/test/test.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var request = require('supertest');  
+var request = require('supertest');
 var fs = require('fs');
 var guid = require('guid');
 
@@ -32,10 +32,10 @@ describe('GET /v2/catalog', function() {
     });
 
     describe('Query service catalog', function() {
-        
+
         testAPIVersionHeader('/v2/catalog', 'GET');
         testAuthentication('/v2/catalog', 'GET');
-        
+
         it('should return list of registered service classes as JSON payload', function(done){
             preparedRequest()
                 .get('/v2/catalog')
@@ -59,17 +59,17 @@ describe('PUT /v2/service_instances/:instance_id', function(){
     config.provisions.forEach(function(provision){
         var instance_id = provision.instance_id;
         if (!instance_id)
-            instance_id = guid.create().value;        
-        describe('PROVISION - request syntax', function() {     
-            
+            instance_id = guid.create().value;
+        describe('PROVISION - request syntax', function() {
+
             testAPIVersionHeader('/v2/service_instances/' + instance_id, 'PUT');
             testAuthentication('/v2/service_instances/' + instance_id, 'PUT');
 
-            if (provision.async) 
+            if (provision.async)
                 testAsyncParameter('/v2/service_instances/' + instance_id, 'PUT');
 
             it ('should reject if missing service_id', function(done){
-                tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                tempBody = JSON.parse(JSON.stringify(provision.body));
                 delete tempBody.service_id;
                 preparedRequest()
                 .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
@@ -79,7 +79,7 @@ describe('PUT /v2/service_instances/:instance_id', function(){
                 .expect(400, done)
             })
             it ('should reject if missing plan_id', function(done){
-                tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                tempBody = JSON.parse(JSON.stringify(provision.body));
                 delete tempBody.plan_id;
                 preparedRequest()
                 .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
@@ -89,7 +89,7 @@ describe('PUT /v2/service_instances/:instance_id', function(){
                 .expect(400, done)
             })
             it ('should reject if request payload is missing organization_guid', function(done){
-                tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                tempBody = JSON.parse(JSON.stringify(provision.body));
                 delete tempBody.organization_guid;
                 preparedRequest()
                 .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
@@ -99,7 +99,7 @@ describe('PUT /v2/service_instances/:instance_id', function(){
                 .expect(400, done)
             })
             it ('should reject if request payload is missing space_guid', function(done){
-                tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                tempBody = JSON.parse(JSON.stringify(provision.body));
                 delete tempBody.space_guid;
                 preparedRequest()
                 .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
@@ -109,7 +109,7 @@ describe('PUT /v2/service_instances/:instance_id', function(){
                 .expect(400, done)
             })
             it ('should reject if service_id is invalid', function(done){
-                tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                tempBody = JSON.parse(JSON.stringify(provision.body));
                 tempBody.service_id = "xxxxx-xxxxx";
                 preparedRequest()
                 .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
@@ -119,7 +119,7 @@ describe('PUT /v2/service_instances/:instance_id', function(){
                 .expect(400, done)
             })
             it ('should reject if plan_id is invalid', function(done){
-                tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                tempBody = JSON.parse(JSON.stringify(provision.body));
                 tempBody.plan_id = "xxxxx-xxxxx";
                 preparedRequest()
                 .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
@@ -129,10 +129,10 @@ describe('PUT /v2/service_instances/:instance_id', function(){
                 .expect(400, done)
             })
             it ('should reject if parameters are not following schema', function(done){
-                tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                tempBody = JSON.parse(JSON.stringify(provision.body));
                 tempBody.parameters = {
                     "can-not": "be-good"
-                }                
+                }
                 preparedRequest()
                 .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
                 .set('X-Broker-API-Version', apiVersion)
@@ -144,7 +144,7 @@ describe('PUT /v2/service_instances/:instance_id', function(){
         if (provision.scenario == "new") {
             describe("PROVISION - new", function () {
                 it ('should accept a valid provision request', function(done){
-                    tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                    tempBody = JSON.parse(JSON.stringify(provision.body));
                     preparedRequest()
                     .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
                     .set('X-Broker-API-Version', apiVersion)
@@ -160,39 +160,41 @@ describe('PUT /v2/service_instances/:instance_id', function(){
                             done();
                     })
                 });
-                
-                testAPIVersionHeader('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
-                testAuthentication('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
 
-                describe("PROVISION - query after new", function() {
-                    it ('should return last operation status', function(done){
-                        preparedRequest()
-                            .get('/v2/service_instances/' + instance_id + '/last_operation')
-                            .set('X-Broker-API-Version', apiVersion)
-                            .auth(config.user, config.password)
-                            .expect(200)
-                            .expect('Content-Type', /json/)
-                            .end(function(err, res){
-                                if (err) return done(err);
-                                var message = validateJsonSchema(res.body, lastOperationSchema);
-                                if (message!="")
-                                    done(new Error(message));
-                                else
-                                    done();
+                if (provision.async) {
+                    testAPIVersionHeader('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
+                    testAuthentication('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
+
+                    describe("PROVISION - query after new", function() {
+                        it ('should return last operation status', function(done){
+                            preparedRequest()
+                                .get('/v2/service_instances/' + instance_id + '/last_operation')
+                                .set('X-Broker-API-Version', apiVersion)
+                                .auth(config.user, config.password)
+                                .expect(200)
+                                .expect('Content-Type', /json/)
+                                .end(function(err, res){
+                                    if (err) return done(err);
+                                    var message = validateJsonSchema(res.body, lastOperationSchema);
+                                    if (message!="")
+                                        done(new Error(message));
+                                    else
+                                        done();
+                                })
                             })
-                        })
-                    });
+                        });
+                }
             });
         } else if (provision.scenario == "conflict") {
             describe("PROVISION - conflict", function () {
                 it ('should return conflict when instance Id exists with different properties', function(done){
-                    tempBody = JSON.parse(JSON.stringify(provision.body)); 
+                    tempBody = JSON.parse(JSON.stringify(provision.body));
                     preparedRequest()
                     .put('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
                     .set('X-Broker-API-Version', apiVersion)
                     .auth(config.user, config.password)
                     .send(tempBody)
-                    .expect(409, done)                    
+                    .expect(409, done)
                 });
             });
         }
@@ -203,17 +205,17 @@ describe('PATCH /v2/service_instance/:instance_id', function() {
     config.updates.forEach(function(update) {
         var instance_id = update.instance_id;
         if (!instance_id)
-            instance_id = guid.create().value;   
-        describe('UPDATE - request syntax', function() {     
-            
+            instance_id = guid.create().value;
+        describe('UPDATE - request syntax', function() {
+
             testAPIVersionHeader('/v2/service_instances/' + instance_id, 'PATCH');
             testAuthentication('/v2/service_instances/' + instance_id, 'PATCH');
 
-            if (update.async) 
+            if (update.async)
                 testAsyncParameter('/v2/service_instances/' + instance_id, 'PATCH');
 
             it ('should reject if missing service_id', function(done){
-                tempBody = JSON.parse(JSON.stringify(update.body)); 
+                tempBody = JSON.parse(JSON.stringify(update.body));
                 delete tempBody.service_id;
                 preparedRequest()
                     .patch('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
@@ -226,7 +228,7 @@ describe('PATCH /v2/service_instance/:instance_id', function() {
         if (update.scenario == "update") {
             describe("UPDATE", function () {
                 it ('should accept a valid update request', function(done){
-                    tempBody = JSON.parse(JSON.stringify(update.body)); 
+                    tempBody = JSON.parse(JSON.stringify(update.body));
                     preparedRequest()
                     .patch('/v2/service_instances/' + instance_id + "?accepts_incomplete=true")
                     .set('X-Broker-API-Version', apiVersion)
@@ -242,28 +244,30 @@ describe('PATCH /v2/service_instance/:instance_id', function() {
                             done();
                     })
                 });
-                
-                testAPIVersionHeader('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
-                testAuthentication('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
 
-                describe("PROVISION - query after new", function() {
-                    it ('should return last operation status', function(done){
-                        preparedRequest()
-                            .get('/v2/service_instances/' + instance_id + '/last_operation')
-                            .set('X-Broker-API-Version', apiVersion)
-                            .auth(config.user, config.password)
-                            .expect(200)
-                            .expect('Content-Type', /json/)
-                            .end(function(err, res){
-                                if (err) return done(err);
-                                var message = validateJsonSchema(res.body, lastOperationSchema);
-                                if (message!="")
-                                    done(new Error(message));
-                                else
-                                    done();
+                if (update.async) {
+                    testAPIVersionHeader('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
+                    testAuthentication('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
+
+                    describe("PROVISION - query after new", function() {
+                        it ('should return last operation status', function(done){
+                            preparedRequest()
+                                .get('/v2/service_instances/' + instance_id + '/last_operation')
+                                .set('X-Broker-API-Version', apiVersion)
+                                .auth(config.user, config.password)
+                                .expect(200)
+                                .expect('Content-Type', /json/)
+                                .end(function(err, res){
+                                    if (err) return done(err);
+                                    var message = validateJsonSchema(res.body, lastOperationSchema);
+                                    if (message!="")
+                                        done(new Error(message));
+                                    else
+                                        done();
+                                })
                             })
-                        })
-                    });
+                        });
+                }
             });
         }
     });
@@ -273,18 +277,18 @@ describe('PUT /v2/service_instance/:instance_id/service_bindings/:binding_id', f
     config.bindings.forEach(function(binding) {
         var instance_id = binding.instance_id;
         if (!instance_id)
-            instance_id = guid.create().value;   
+            instance_id = guid.create().value;
         var binding_id = binding.binding_id;
         if (!binding_id)
-            binding_id = guid.create().value;   
-        
-        describe('BINDING - request syntax', function() {     
-                                
+            binding_id = guid.create().value;
+
+        describe('BINDING - request syntax', function() {
+
             testAPIVersionHeader('/v2/service_instances/' + instance_id + '/service_bindings/' + binding_id, 'PUT');
             testAuthentication('/v2/service_instances/' + instance_id + '/service_bindings/' + binding_id, 'PUT');
 
             it ('should reject if missing service_id', function(done){
-                tempBody = JSON.parse(JSON.stringify(binding.body)); 
+                tempBody = JSON.parse(JSON.stringify(binding.body));
                 delete tempBody.service_id;
                 preparedRequest()
                     .put('/v2/service_instances/' + instance_id +  '/service_bindings/' + binding_id)
@@ -294,7 +298,7 @@ describe('PUT /v2/service_instance/:instance_id/service_bindings/:binding_id', f
                     .expect(400, done)
             })
             it ('should reject if missing plan_id', function(done){
-                tempBody = JSON.parse(JSON.stringify(binding.body)); 
+                tempBody = JSON.parse(JSON.stringify(binding.body));
                 delete tempBody.plan_id;
                 preparedRequest()
                     .put('/v2/service_instances/' + instance_id +  '/service_bindings/' + binding_id)
@@ -307,7 +311,7 @@ describe('PUT /v2/service_instance/:instance_id/service_bindings/:binding_id', f
             if (binding.scenario == "new") {
                 describe("NEW", function () {
                     it ('should accept a valid binding request', function(done){
-                        tempBody = JSON.parse(JSON.stringify(binding.body)); 
+                        tempBody = JSON.parse(JSON.stringify(binding.body));
                         preparedRequest()
                         .put('/v2/service_instances/' + instance_id +  '/service_bindings/' + binding_id)
                         .set('X-Broker-API-Version', apiVersion)
@@ -334,34 +338,34 @@ describe('DELETE /v2/service_instance/:instance_id/service_bindings/:binding_id'
         if (binding.scenario == "delete") {
             var instance_id = binding.instance_id;
             if (!instance_id)
-                instance_id = guid.create().value;   
+                instance_id = guid.create().value;
             var binding_id = binding.binding_id;
             if (!binding_id)
-                binding_id = guid.create().value;   
-            describe('BINDING - delete syntax', function() {     
-                
+                binding_id = guid.create().value;
+            describe('BINDING - delete syntax', function() {
+
                 testAPIVersionHeader('/v2/service_instances/' + instance_id + '/service_bindings/' + binding_id, 'DELETE');
                 testAuthentication('/v2/service_instances/' + instance_id + '/service_bindings/' + binding_id, 'DELETE');
 
                 describe('DELETE', function () {
-                    it ('should reject if missing service_id', function(done) {                
+                    it ('should reject if missing service_id', function(done) {
                         preparedRequest()
                             .delete('/v2/service_instances/' + instance_id +  '/service_bindings/' + binding_id + "?plan_id=" + binding.body.plan_id)
                             .set('X-Broker-API-Version', apiVersion)
                             .auth(config.user, config.password)
                             .expect(400, done)
                     })
-                    it ('should reject if missing plan_id', function(done){                
+                    it ('should reject if missing plan_id', function(done){
                         preparedRequest()
-                            .delete('/v2/service_instances/' + instance_id +  '/service_bindings/' + binding_id + "?service_id=" + binding.body.service_id)                    
+                            .delete('/v2/service_instances/' + instance_id +  '/service_bindings/' + binding_id + "?service_id=" + binding.body.service_id)
                             .set('X-Broker-API-Version', apiVersion)
                             .auth(config.user, config.password)
                             .expect(400, done)
                         })
                     it ('should accept a valid binding deletion request', function(done){
-                        tempBody = JSON.parse(JSON.stringify(binding.body)); 
+                        tempBody = JSON.parse(JSON.stringify(binding.body));
                         preparedRequest()
-                            .delete('/v2/service_instances/' + instance_id +  '/service_bindings/' + binding_id 
+                            .delete('/v2/service_instances/' + instance_id +  '/service_bindings/' + binding_id
                                 + "?plan_id=" + binding.body.plan_id
                                 + "&service_id=" + binding.body.service_id)
                             .set('X-Broker-API-Version', apiVersion)
@@ -387,10 +391,10 @@ describe('DELETE /v2/service_instance/:instance_id', function() {
         if (binding.scenario == "delete") {
             var instance_id = binding.instance_id;
             if (!instance_id)
-                instance_id = guid.create().value;   
-            
-            describe('DEPROVISIONING - delete syntax', function() {     
-                
+                instance_id = guid.create().value;
+
+            describe('DEPROVISIONING - delete syntax', function() {
+
                 testAPIVersionHeader('/v2/service_instances/' + instance_id, 'DELETE');
                 testAuthentication('/v2/service_instances/' + instance_id, 'DELETE');
 
@@ -401,25 +405,25 @@ describe('DELETE /v2/service_instance/:instance_id', function() {
                         + "&service_id=" + binding.body.service_id,
                         'DELETE');
 
-                describe("DELETE", function () { 
-                    it ('should reject if missing service_id', function(done) {                
+                describe("DELETE", function () {
+                    it ('should reject if missing service_id', function(done) {
                         preparedRequest()
                             .delete('/v2/service_instances/' + instance_id + "?accepts_incomplete=true&plan_id=" + binding.body.plan_id)
                             .set('X-Broker-API-Version', apiVersion)
                             .auth(config.user, config.password)
                             .expect(400, done)
                     })
-                    it ('should reject if missing plan_id', function(done){                
+                    it ('should reject if missing plan_id', function(done){
                         preparedRequest()
-                            .delete('/v2/service_instances/' + instance_id + "?accepts_incomplete=true&service_id=" + binding.body.service_id)                    
+                            .delete('/v2/service_instances/' + instance_id + "?accepts_incomplete=true&service_id=" + binding.body.service_id)
                             .set('X-Broker-API-Version', apiVersion)
                             .auth(config.user, config.password)
                             .expect(400, done)
                         })
                     it ('should accept a valid service deletion request', function(done){
-                        tempBody = JSON.parse(JSON.stringify(binding.body)); 
+                        tempBody = JSON.parse(JSON.stringify(binding.body));
                         preparedRequest()
-                            .delete('/v2/service_instances/' + instance_id 
+                            .delete('/v2/service_instances/' + instance_id
                                 + "?accepts_incomplete=true&plan_id=" + binding.body.plan_id
                                 + "&service_id=" + binding.body.service_id)
                             .set('X-Broker-API-Version', apiVersion)
@@ -497,35 +501,35 @@ function testAuthentication(handler, verb) {
                     .expect(401, done);
             }
         })
-    }    
+    }
 }
 
 function testAPIVersionHeader(handler, verb) {
     it('should reject requests without X-Broker-API-Version header with 412', function(done) {
         if (verb == 'GET') {
             preparedRequest()
-                .get(handler)                    
+                .get(handler)
                 .auth(config.user, config.password)
                 .expect(412, done)
         } else if (verb == 'PUT') {
             preparedRequest()
-                .put(handler)                    
+                .put(handler)
                 .auth(config.user, config.password)
                 .send({})
                 .expect(412, done)
         } else if (verb == 'PATCH') {
             preparedRequest()
-                .patch(handler)                    
+                .patch(handler)
                 .auth(config.user, config.password)
                 .send({})
                 .expect(412, done)
         } else if (verb == 'DELETE') {
             preparedRequest()
-                .delete(handler)                    
+                .delete(handler)
                 .auth(config.user, config.password)
                 .expect(412, done)
         }
-    })     
+    })
 }
 function testAsyncParameter(handler, verb) {
     it ('should return 422 if request doesn\'t have the accepts_incomplete parameter', function(done) {


### PR DESCRIPTION
The `last_operation` [path](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#polling-last-operation) is only hit if the SB returns a 202, which happens only if the SB allows async requests.

This PR updates the OSB checker to only check the `last_operation` path if the SB allows async requests. It also cleans up some whitespace, which may be repeating some work that was done in [PR 2](https://github.com/openservicebrokerapi/osb-checker/pull/2) - this was automatically done by my IDE. I will be happy to clean up this PR once the PR 2 changes are merged; lmk.