### PR TITLE
Fix JSON parse error in poll last operation scenario

### DIFF
--- a/2.13/tests/test/test.js
+++ b/2.13/tests/test/test.js
@@ -230,7 +230,7 @@ describe('PATCH /v2/service_instance/:instance_id', function() {
                 testAuthentication('/v2/service_instances/' + instance_id + '/last_operation', 'GET');
 
                 let testLastOperationStatus = function(body, done) {
-                    operation = JSON.parse(body.operation)
+                    operation = body.operation
                     endpoint = '/v2/service_instances/' + instance_id + '/last_operation'
                     if (operation) {
                         endpoint += "?operation=" + JSON.stringify(operation)


### PR DESCRIPTION
Signed-off-by: leonwanghui <wanghui71leon@gmail.com>

## Problem description
When I first try `npm test` for mock broker, it seems that there is one use case that always fail with errors below:
```shell
  85 passing (214ms)
  1 failing

  1) PATCH /v2/service_instance/:instance_id
       UPDATE
         should accept a valid update request:
     Uncaught SyntaxError: Unexpected token a in JSON at position 1
      at JSON.parse (<anonymous>)
      at testLastOperationStatus (test/test.js:233:38)
      at Test.<anonymous> (test/test.js:265:29)
      at Test.assert (node_modules/supertest/lib/test.js:181:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:706:12)
      at parser (node_modules/superagent/lib/node/index.js:906:18)
      at IncomingMessage.res.on (node_modules/superagent/lib/node/parsers/json.js:19:7)
      at endReadableNT (_stream_readable.js:1086:12)
      at process._tickCallback (internal/process/next_tick.js:63:19)
```

## Proposed solution
To solve the problem, I modified one line in `test.js` and then it works fine.

Please notice that this patch could have impact on #32 .