### PR TITLE
Make schema extensible and flexible

### DIFF
--- a/2.13/tests/test/schemas/binding_delete_response.json
+++ b/2.13/tests/test/schemas/binding_delete_response.json
@@ -5,5 +5,5 @@
     "type": "object",
     "properties": {
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/2.13/tests/test/schemas/binding_response.json
+++ b/2.13/tests/test/schemas/binding_response.json
@@ -37,5 +37,5 @@
             }
         }
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/2.13/tests/test/schemas/last_operation.json
+++ b/2.13/tests/test/schemas/last_operation.json
@@ -15,5 +15,5 @@
             "pattern": "\\S+"
         }
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/2.13/tests/test/schemas/provision_response.json
+++ b/2.13/tests/test/schemas/provision_response.json
@@ -13,5 +13,5 @@
             "pattern": "\\S+"
         }
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/2.13/tests/test/schemas/provisioning_delete_response.json
+++ b/2.13/tests/test/schemas/provisioning_delete_response.json
@@ -9,5 +9,5 @@
             "pattern": "\\S+"
         }
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/2.13/tests/test/schemas/service_catalog.json
+++ b/2.13/tests/test/schemas/service_catalog.json
@@ -122,5 +122,5 @@
             }
         }
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/2.13/tests/test/schemas/update_response.json
+++ b/2.13/tests/test/schemas/update_response.json
@@ -9,5 +9,5 @@
             "pattern": "\\S+"
         }
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }


### PR DESCRIPTION
For broker implementation of some service providers, they have enhanced some features by adding some additional fields in the schema. But currently `validateJSONSchema` method doesn't work because the definition of schema is fixed, so this patch is proposed to make schema more flexible so that service providers can implement some advanced features at the same time passing validation check.