### PR TITLE
Fix some bugs in provision and bind response status code

### DIFF
--- a/2.13/mocks/mockOSB.js
+++ b/2.13/mocks/mockOSB.js
@@ -69,7 +69,12 @@ app.put('/v2/service_instances/:instance_id', function (req, res) {
   }
 
   if (serviceInstanceExists(req.body.service_id, req.body.plan_id, req.params.instance_id)) {
-    res.status(200).send({})
+    res.status(200).send(
+      {
+        'dashboard_url': 'http://example-dashboard.example.com/9189kdfsk0vfnku',
+        'operation': 'task_10'
+      }
+    )
     return
   } else {
     serviceInstances.push({
@@ -137,7 +142,16 @@ app.put('/v2/service_instances/:instance_id/service_bindings/:binding_id', funct
   }
 
   if (serviceBindingExists(req.body.service_id, req.body.plan_id, req.params.instance_id, req.params.binding_id)) {
-    res.status(200).send({})
+    res.status(200).send({
+      'credentials': {
+        'uri': 'mysql://mysqluser:pass@mysqlhost:3306/dbname',
+        'username': 'mysqluser',
+        'password': 'pass',
+        'host': 'mysqlhost',
+        'port': 3306,
+        'database': 'dbname'
+      }
+    })
     return
   } else {
     serviceBindings.push({

--- a/2.13/tests/test/test.js
+++ b/2.13/tests/test/test.js
@@ -266,7 +266,12 @@ function testProvision (instanceId, validBody, isAsync) {
         .set('X-Broker-API-Version', apiVersion)
         .auth(config.user, config.password)
         .send(tempBody)
-        .expect(200, done)
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err)
+          var message = validateJsonSchema(res.body, provisionResponseSchema)
+          if (message !== '') { done(new Error(message)) } else { done() }
+        })
     })
   })
 
@@ -440,7 +445,12 @@ function testBind (instanceId, bindingId, validBody) {
             .set('X-Broker-API-Version', apiVersion)
             .auth(config.user, config.password)
             .send(tempBody)
-            .expect(200, done)
+            .expect(200)
+            .end(function (err, res) {
+              if (err) return done(err)
+              var message = validateJsonSchema(res.body, bindingResponseSchema)
+              if (message !== '') { done(new Error(message)) } else { done() }
+            })
         })
       })
 


### PR DESCRIPTION
Signed-off-by: leonwanghui <wanghui71leon@gmail.com>

According to 2.13 spec, when broker returns `200 OK` in provision and bind cases, the response should be not empty. And the mock server is also updated.