### PR TITLE
Decoupling config_mock.json and other components

### DIFF
--- a/2.13/tests/package.json
+++ b/2.13/tests/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "express": "^4.16.1",
     "mocha": "^4.0.0",
-    "supertest": "^3.0.0",
     "guid": "^0.0.12",
     "underscore": "1.9.1"
   },

--- a/2.13/tests/test/test.js
+++ b/2.13/tests/test/test.js
@@ -2,7 +2,13 @@
 var guid = require('guid')
 var _ = require('underscore')
 
-var config = require('./configs/config_mock.json')
+var config
+if (!process.env['OSB_CHECKER_CONFIG_FILE']) {
+  config = require('./configs/config_mock.json')
+} else {
+  config = require(process.env['OSB_CHECKER_CONFIG_FILE'])
+}
+require('../../../common/config').setConfig(config)
 
 var testCatalog = require('../../../common/testCatalog')
 var testProvision = require('../../../common/testProvision')

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ docker run -it --net=host osb-checker/test-job:$VERSION_NUMBER
 Follow the below instructions to run tests against your own OSBAPI
 compatible server.
 
-1. Modify test configurations. By default, test parameters are loaded from the
+1. Set test configurations. By default, test parameters are loaded from the
    `test\config_mock.json` file so that you can run tests directly against the mock
-   server. For your own environment, you should create a new config file based on
-   `test\config_mock.json` and fill in your OSB endpoint info:
+   server. For your own environment, your configurations should follow the format of
+   `test\config_mock.json` and set the environment variable `OSB_CHECKER_CONFIG_FILE`
+   with your configurations file path.
 
 ```json
 "url": "<your OSB endpoint>",
@@ -65,24 +66,17 @@ compatible server.
 If your server uses TLS with an untrusted certificate authority, specify the
 path to the CA certificate using the `caCertFile` property.
 
-2. Modify your test configuration file to use match with your environment,
-   such as using the correct service ids and plan ids. OSB-Checker is data-driven.
-   You can define more test cases by modifying the test configuration file.
-   For instance, to add a new service instance provision case, simply add a new
-   item into the `provisions` array.
-
-> **CALL TO ACTION** Please contribute your test configurations back to the community.
-
-3. Update **test.js** to use your own configuration:
-
-```javascript
-var config = require("./configs/config_mock.json"); //replace config_mock.json with your own configuration file
-```
-
-4. Run tests
+2. Run tests
 
 ```bash
     cd $DIRECTORY/$VERSION_NUMBER/tests/test && npm test
+```
+
+or set `OSB_CHECKER_CONFIG_FILE` inline:
+
+```bash
+    cd $DIRECTORY/$VERSION_NUMBER/tests/test
+    OSB_CHECKER_CONFIG_FILE="<config-path>" npm test
 ```
 
 # What's Covered

--- a/common/config.js
+++ b/common/config.js
@@ -1,0 +1,11 @@
+// It should be assigned by the test framework
+var config = {}
+
+module.exports = {
+  setConfig: function (_config) {
+    config = _config
+  },
+  getConfig: function () {
+    return config
+  }
+}

--- a/common/package.json
+++ b/common/package.json
@@ -4,8 +4,9 @@
   "author": "Haishi",
   "license": "MIT",
   "dependencies": {
+    "async": "2.6.1",
     "jsonschema": "^1.2.0",
-    "underscore": "1.9.1",
-    "async": "2.6.1"
+    "supertest": "^3.3.0",
+    "underscore": "1.9.1"
   }
 }

--- a/common/pollInstanceLastOperationStatus.js
+++ b/common/pollInstanceLastOperationStatus.js
@@ -2,8 +2,8 @@ var async = require('async')
 
 var validateJsonSchema = require('./validateJsonSchema')
 
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 var lastOperationSchema
 
 function pollInstanceLastOperationStatus (instanceId, lastOperationName, apiVersion, done) {
@@ -11,8 +11,6 @@ function pollInstanceLastOperationStatus (instanceId, lastOperationName, apiVers
     apiVersion = '2.13'
   }
   if (apiVersion === '2.13') {
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
     lastOperationSchema = require('../2.13/tests/test/schemas/last_operation.json')
   } else {
     // supprt 2.14 here

--- a/common/preparedRequest.js
+++ b/common/preparedRequest.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var request = require('supertest')
 
-var config = require('./configs/config_mock.json')
+var config = require('./config').getConfig()
 var url = config.url
 
 var caCert

--- a/common/testAPIVersionHeader.js
+++ b/common/testAPIVersionHeader.js
@@ -1,16 +1,13 @@
 /* eslint-env node, mocha */
-var config
-var preparedRequest
+require('./config')
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 function testAPIVersionHeader (handler, verb, apiVersion) {
   if (!apiVersion) {
     apiVersion = '2.13'
   }
-  if (apiVersion === '2.13') {
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
-  } else {
-    // supprt 2.14 here
+  if (apiVersion !== '2.13') {
     throw Error('testAPIVersionHeader doesn\'t support this api version')
   }
 

--- a/common/testAsyncParameter.js
+++ b/common/testAsyncParameter.js
@@ -1,16 +1,12 @@
 /* eslint-env node, mocha */
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 function testAsyncParameter (handler, verb, body, apiVersion) {
   if (!apiVersion) {
     apiVersion = '2.13'
   }
-  if (apiVersion === '2.13') {
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
-  } else {
-    // supprt 2.14 here
+  if (apiVersion !== '2.13') {
     throw Error('testAsyncParameter doesn\'t support this api version')
   }
 

--- a/common/testAuthentication.js
+++ b/common/testAuthentication.js
@@ -1,16 +1,12 @@
 /* eslint-env node, mocha */
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 function testAuthentication (handler, verb, apiVersion) {
   if (!apiVersion) {
     apiVersion = '2.13'
   }
-  if (apiVersion === '2.13') {
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
-  } else {
-    // supprt 2.14 here
+  if (apiVersion !== '2.13') {
     throw Error('testAuthentication doesn\'t support this api version')
   }
 

--- a/common/testBind.js
+++ b/common/testBind.js
@@ -9,8 +9,8 @@ var constants = require('./constants')
 var validateJsonSchema = require('./validateJsonSchema')
 
 var bindingResponseSchema
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 function testBind (instanceId, bindingId, validBody, apiVersion) {
   if (!apiVersion) {
@@ -18,8 +18,6 @@ function testBind (instanceId, bindingId, validBody, apiVersion) {
   }
   if (apiVersion === '2.13') {
     bindingResponseSchema = require('../2.13/tests/test/schemas/binding_response.json')
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
   } else {
     // supprt 2.14 here
     throw Error('testBind doesn\'t support this api version')

--- a/common/testCatalog.js
+++ b/common/testCatalog.js
@@ -4,8 +4,8 @@ var testAuthentication = require('./testAuthentication')
 var validateJsonSchema = require('./validateJsonSchema')
 
 var serviceCatalogSchema
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 function testCatalog (apiVersion) {
   if (!apiVersion) {
@@ -13,8 +13,6 @@ function testCatalog (apiVersion) {
   }
   if (apiVersion === '2.13') {
     serviceCatalogSchema = require('../2.13/tests/test/schemas/service_catalog.json')
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
   } else {
     // supprt 2.14 here
     throw Error('testCatalog doesn\'t support this api version')

--- a/common/testDeprovision.js
+++ b/common/testDeprovision.js
@@ -6,8 +6,8 @@ var pollInstanceLastOperationStatus = require('./pollInstanceLastOperationStatus
 var validateJsonSchema = require('./validateJsonSchema')
 
 var provisioningDeleteResponseSchema
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 var maxDelayTimeout = 1800
 
@@ -17,8 +17,6 @@ function testDeprovision (instanceId, queryStrings, isAsync, apiVersion) {
   }
   if (apiVersion === '2.13') {
     provisioningDeleteResponseSchema = require('../2.13/tests/test/schemas/provisioning_delete_response.json')
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
   } else {
     // supprt 2.14 here
     throw Error('testDeprovision doesn\'t support this api version')

--- a/common/testProvision.js
+++ b/common/testProvision.js
@@ -11,8 +11,8 @@ var constants = require('./constants')
 var validateJsonSchema = require('./validateJsonSchema')
 
 var provisionResponseSchema
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 var maxDelayTimeout = 1800
 
@@ -22,8 +22,6 @@ function testProvision (instanceId, validBody, isAsync, apiVersion) {
   }
   if (apiVersion === '2.13') {
     provisionResponseSchema = require('../2.13/tests/test/schemas/provision_response.json')
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
   } else {
     // supprt 2.14 here
     throw Error('testProvision doesn\'t support this api version')

--- a/common/testUnbind.js
+++ b/common/testUnbind.js
@@ -4,8 +4,8 @@ var testAuthentication = require('./testAuthentication')
 var validateJsonSchema = require('./validateJsonSchema')
 
 var bindingDeleteResponseSchema
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 function testUnbind (instanceId, bindingId, queryStrings, apiVersion) {
   if (!apiVersion) {
@@ -13,8 +13,6 @@ function testUnbind (instanceId, bindingId, queryStrings, apiVersion) {
   }
   if (apiVersion === '2.13') {
     bindingDeleteResponseSchema = require('../2.13/tests/test/schemas/binding_delete_response.json')
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
   } else {
     // supprt 2.14 here
     throw Error('testUnbind doesn\'t support this api version')

--- a/common/testUpdate.js
+++ b/common/testUpdate.js
@@ -11,8 +11,8 @@ var constants = require('./constants')
 var validateJsonSchema = require('./validateJsonSchema')
 
 var updateResponseSchema
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 var maxDelayTimeout = 1800
 
@@ -22,8 +22,6 @@ function testUpdate (instanceId, validBody, isAsync, apiVersion) {
   }
   if (apiVersion === '2.13') {
     updateResponseSchema = require('../2.13/tests/test/schemas/update_response.json')
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
   } else {
     // supprt 2.14 here
     throw Error('testUpdate doesn\'t support this api version')

--- a/common/validateCatalogSchema.js
+++ b/common/validateCatalogSchema.js
@@ -3,18 +3,14 @@ var _ = require('underscore')
 var constants = require('./constants')
 var validateJsonSchema = require('./validateJsonSchema')
 
-var config
-var preparedRequest
+var config = require('./config').getConfig()
+var preparedRequest = require('./preparedRequest')
 
 function validateCatalogSchema (tempBody, schemaType, action, apiVersion) {
   if (!apiVersion) {
     apiVersion = '2.13'
   }
-  if (apiVersion === '2.13') {
-    config = require('../2.13/tests/test/configs/config_mock.json')
-    preparedRequest = require('../2.13/tests/test/preparedRequest')
-  } else {
-    // supprt 2.14 here
+  if (apiVersion !== '2.13') {
     throw Error('validateCatalogSchema doesn\'t support this api version')
   }
 


### PR DESCRIPTION
And now it is able to run `OSB_CHECKER_CONFIG_FILE="<custome-config-file-path>" npm test` instead of modifying `config_mock.json`.