### PR TITLE
Remove applied test case in update operation

### DIFF
--- a/common/testUpdate.js
+++ b/common/testUpdate.js
@@ -100,18 +100,6 @@ function testUpdate (instanceId, validBody, isAsync, apiVersion) {
         })
       })
     }
-
-    describe('UPDATE - applied', function () {
-      it('should return 200 OK when the request changes have been applied', function (done) {
-        var tempBody = _.clone(validBody)
-        preparedRequest()
-          .patch('/v2/service_instances/' + instanceId + '?accepts_incomplete=true')
-          .set('X-Broker-API-Version', apiVersion)
-          .auth(config.user, config.password)
-          .send(tempBody)
-          .expect(200, done)
-      })
-    })
   })
 }
 


### PR DESCRIPTION
Generally this patch will remove `Update - applied` test case in `testUpdate.js` with reasons below:
* For most platforms (k8s or openshift), they will lock any operation of that instance if async operation is not finished, so normally users can't perform the update request twice manually through the platform
* Even if users can perform the update request twice (the second one comes after the first one finished), broker can also return 202 and then the platform trigger `lastOperation`
* If the second one comes before the first one finished, according to the 2.13 sepc, the broker should return 202 rather than 200.

So it's better to keep the broker return 202 for all three scenarios before, and therefore the applied test should be removed.