### PR TITLE
Bug fix for test case in provision.go

### DIFF
--- a/test/common/provision.go
+++ b/test/common/provision.go
@@ -41,9 +41,11 @@ func TestProvision(
 
 		if async {
 			Convey("should return 422 UnprocessableEntity if missing accepts_incomplete", func() {
+				tempBody := openapi.ServiceInstanceProvisionRequest{}
+				deepCopy(req, &tempBody)
 				_, resp, err := cli.ServiceInstancesApi.ServiceInstanceProvision(
-					authCtx, CONF.APIVersion, instanceID, openapi.ServiceInstanceProvisionRequest{},
-					&openapi.ServiceInstanceProvisionOpts{AcceptsIncomplete: optional.NewBool(false)})
+					authCtx, CONF.APIVersion, instanceID, tempBody,
+					&openapi.ServiceInstanceProvisionOpts{})
 
 				So(err, ShouldNotBeNil)
 				So(resp.StatusCode, ShouldEqual, 422)


### PR DESCRIPTION
This change fixes a bug found in the test case that's testing this: 
`should return 422 UnprocessableEntity if missing accepts_incomplete`

The required body was missing and it should also solve this issue https://github.com/openservicebrokerapi/osb-checker/issues/30 